### PR TITLE
Fix vercel config conflict

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,39 +1,30 @@
 {
-    "version": 2,
-    "builds": [
-        {
-            "src": "package.json",
-            "use": "@vercel/next"
-        },
-        {
-            "src": "api/[...path].py",
-            "use": "@vercel/python"
-        }
-    ],
-    "routes": [
-        {
-            "src": "/api/(.*)",
-            "dest": "/api/[...path].py"
-        },
-        {
-            "src": "/stream/(.*)",
-            "dest": "/api/[...path].py"
-        },
-        {
-            "handle": "filesystem"
-        },
-        {
-            "src": "/(.*)",
-            "dest": "/$1"
-        }
-    ],
-    "functions": {
-        "api/[...path].py": {
-            "maxDuration": 30
-        }
+  "version": 2,
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "/api/[...path].py"
     },
-    "env": {
-        "USE_MOCK": "true",
-        "AUTH_SECRET": "ryH*!GGTc33Y*D"
+    {
+      "src": "/stream/(.*)",
+      "dest": "/api/[...path].py"
+    },
+    {
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/$1"
     }
+  ],
+  "functions": {
+    "api/[...path].py": {
+      "maxDuration": 30
+    }
+  },
+  "env": {
+    "USE_MOCK": "true",
+    "AUTH_SECRET": "ryH*!GGTc33Y*D"
+  }
 }
+


### PR DESCRIPTION
## Summary
- update `vercel.json` to remove the deprecated `builds` section

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef77802a88325976e530e12068072