### PR TITLE
Enable pgcrypto extension and document

### DIFF
--- a/docs/db-setup.md
+++ b/docs/db-setup.md
@@ -1,0 +1,24 @@
+# Database Setup
+
+## Enable pgcrypto Extension (required)
+
+The project relies on PostgreSQL's `pgcrypto` extension for generating UUIDs and other cryptographic helpers (e.g. `gen_random_uuid()`). Make sure it is enabled in **all** environments (local, dev, staging, prod).
+
+```sql
+-- connect to the database first, then run:
+create extension if not exists pgcrypto;
+```
+
+If you are using Supabase locally, you can apply the migration in the `supabase/migrations` directory or execute it manually:
+
+```bash
+psql "$SUPABASE_DB_URL" -c "create extension if not exists pgcrypto;"
+```
+
+After enabling the extension, verify that it works:
+
+```sql
+select gen_random_uuid(); -- should return a UUID value
+```
+
+> Important: Avoid enabling unnecessary extensions or any features that require superuser privileges on managed Supabase Postgres instances.

--- a/supabase/migrations/202509212100_enable_pgcrypto.sql
+++ b/supabase/migrations/202509212100_enable_pgcrypto.sql
@@ -1,0 +1,1 @@
+create extension if not exists pgcrypto;


### PR DESCRIPTION
Enable `pgcrypto` extension for UUID generation and cryptographic functions, and document its setup.

---
Linear Issue: [GOO-40](https://linear.app/goodly-development/issue/GOO-40/db-enable-pgcrypto-and-base-extensions)

<a href="https://cursor.com/background-agent?bcId=bc-56983824-5e5e-4cca-9f29-dbc2b3dca79a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56983824-5e5e-4cca-9f29-dbc2b3dca79a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

